### PR TITLE
NO SUDO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: "python"
+sudo: false
 
 branches:
   only:


### PR DESCRIPTION
This prohibits the use of sudo in the build (which we don't need); as a side effect, this activates containerized builds and caching.
