### PR TITLE
Assert equality instead of identity.

### DIFF
--- a/xmantissa/test/test_publicweb.py
+++ b/xmantissa/test/test_publicweb.py
@@ -987,7 +987,7 @@ class CustomizedPublicPageTests(TestCase):
 
         self.assertIsInstance(wrapper, _CustomizingResource)
         self.assertIdentical(wrapper.currentResource, result)
-        self.assertIdentical(resultSegs, ())
+        self.assertEqual(resultSegs, ())
 
 
 


### PR DESCRIPTION
On CPython, `()` appears to be a singleton, but on PyPy this is not true, you can have multiple different empty tuple objects. This test asserts identity for no good reason (or at least, no good reason I can discern), so just change it to assert equality instead.
