### PR TITLE
Generate default certificate with Cryptography instead of certcreate

### DIFF
--- a/axiom/plugins/mantissacmd.py
+++ b/axiom/plugins/mantissacmd.py
@@ -18,7 +18,7 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.x509.oid import NameOID
+from cryptography.x509.oid import NameOID, ExtendedKeyUsageOID
 
 from xmantissa.ixmantissa import IOfferingTechnician
 from xmantissa import webadmin, publicweb, stats
@@ -146,6 +146,20 @@ class Mantissa(axiomatic.AxiomaticCommand):
             .add_extension(
                 x509.BasicConstraints(ca=False, path_length=None),
                 critical=True)
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    content_commitment=False,
+                    key_encipherment=True,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=False,
+                    crl_sign=False,
+                    encipher_only=False,
+                    decipher_only=False))
+            .add_extension(
+                x509.ExtendedKeyUsage([
+                    ExtendedKeyUsageOID.SERVER_AUTH]))
             .sign(
                 private_key=privateKey,
                 algorithm=hashes.SHA256(),

--- a/axiom/plugins/mantissacmd.py
+++ b/axiom/plugins/mantissacmd.py
@@ -140,12 +140,12 @@ class Mantissa(axiomatic.AxiomaticCommand):
             .serial_number(serial)
             .public_key(publicKey)
             .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True)
+            .add_extension(
                 x509.SubjectAlternativeName([
                     x509.DNSName(hostname)]),
                 critical=False)
-            .add_extension(
-                x509.BasicConstraints(ca=False, path_length=None),
-                critical=True)
             .add_extension(
                 x509.KeyUsage(
                     digital_signature=True,
@@ -157,7 +157,7 @@ class Mantissa(axiomatic.AxiomaticCommand):
                     crl_sign=False,
                     encipher_only=False,
                     decipher_only=False),
-                critical=False)
+                critical=True)
             .add_extension(
                 x509.ExtendedKeyUsage([
                     ExtendedKeyUsageOID.SERVER_AUTH]),

--- a/axiom/plugins/mantissacmd.py
+++ b/axiom/plugins/mantissacmd.py
@@ -140,6 +140,10 @@ class Mantissa(axiomatic.AxiomaticCommand):
             .serial_number(serial)
             .public_key(publicKey)
             .add_extension(
+                x509.SubjectAlternativeName([
+                    x509.DNSName(hostname)]),
+                critical=False)
+            .add_extension(
                 x509.BasicConstraints(ca=False, path_length=None),
                 critical=True)
             .sign(

--- a/axiom/plugins/mantissacmd.py
+++ b/axiom/plugins/mantissacmd.py
@@ -131,20 +131,21 @@ class Mantissa(axiomatic.AxiomaticCommand):
         publicKey = privateKey.public_key()
         name = x509.Name([
             x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
-        certificate = x509.CertificateBuilder(
-            ).subject_name(name
-            ).issuer_name(name
-            ).not_valid_before(datetime.today() - timedelta(days=1)
-            ).not_valid_after(datetime.today() + timedelta(days=365)
-            ).serial_number(serial
-            ).public_key(publicKey
-            ).add_extension(
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(name)
+            .issuer_name(name)
+            .not_valid_before(datetime.today() - timedelta(days=1))
+            .not_valid_after(datetime.today() + timedelta(days=365))
+            .serial_number(serial)
+            .public_key(publicKey)
+            .add_extension(
                 x509.BasicConstraints(ca=False, path_length=None),
-                critical=True,
-            ).sign(
+                critical=True)
+            .sign(
                 private_key=privateKey,
                 algorithm=hashes.SHA256(),
-                backend=default_backend())
+                backend=default_backend()))
         return '\n'.join([
             privateKey.private_bytes(
                 encoding=serialization.Encoding.PEM,

--- a/axiom/plugins/mantissacmd.py
+++ b/axiom/plugins/mantissacmd.py
@@ -1,5 +1,6 @@
 
 import sys, os, struct
+from datetime import datetime, timedelta
 
 from zope.interface import directlyProvides
 
@@ -12,6 +13,12 @@ from axiom.scripts import axiomatic
 from axiom.attributes import AND
 from axiom.dependency import installOn
 from axiom.iaxiom import IVersion
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 from xmantissa.ixmantissa import IOfferingTechnician
 from xmantissa import webadmin, publicweb, stats
@@ -27,7 +34,6 @@ from xmantissa.port import PortConfiguration
 from xmantissa import version
 
 from epsilon.asplode import splode
-from epsilon.scripts import certcreate
 
 directlyProvides(version, IPlugin, IVersion)
 
@@ -105,16 +111,57 @@ class Mantissa(axiomatic.AxiomaticCommand):
             self.installAdmin, siteStore, adminLocal, adminDomain, adminPassword)
 
 
+    def _createCert(self, hostname, serial):
+        """
+        Create a self-signed X.509 certificate.
+
+        @type hostname: L{unicode}
+        @param hostname: The hostname this certificate should be valid for.
+
+        @type serial: L{int}
+        @param serial: The serial number the certificate should have.
+
+        @rtype: L{bytes}
+        @return: The serialized certificate in PEM format.
+        """
+        privateKey = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+            backend=default_backend())
+        publicKey = privateKey.public_key()
+        name = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+        certificate = x509.CertificateBuilder(
+            ).subject_name(name
+            ).issuer_name(name
+            ).not_valid_before(datetime.today() - timedelta(days=1)
+            ).not_valid_after(datetime.today() + timedelta(days=365)
+            ).serial_number(serial
+            ).public_key(publicKey
+            ).add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            ).sign(
+                private_key=privateKey,
+                algorithm=hashes.SHA384(),
+                backend=default_backend())
+        return '\n'.join([
+            privateKey.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption()),
+            certificate.public_bytes(
+                encoding=serialization.Encoding.PEM),
+            ])
+
+
     def installSite(self, siteStore, domain, publicURL, generateCert=True):
         """
         Create the necessary items to run an HTTP server and an SSH server.
         """
         certPath = siteStore.filesdir.child("server.pem")
         if generateCert and not certPath.exists():
-            certcreate.main([
-                    '--filename', certPath.path, '--quiet',
-                    '--serial-number', str(genSerial()),
-                    '--hostname', domain])
+            certPath.setContent(self._createCert(domain, genSerial()))
 
         # Install the base Mantissa offering.
         IOfferingTechnician(siteStore).installOffering(baseOffering)

--- a/axiom/plugins/mantissacmd.py
+++ b/axiom/plugins/mantissacmd.py
@@ -143,7 +143,7 @@ class Mantissa(axiomatic.AxiomaticCommand):
                 critical=True,
             ).sign(
                 private_key=privateKey,
-                algorithm=hashes.SHA384(),
+                algorithm=hashes.SHA256(),
                 backend=default_backend())
         return '\n'.join([
             privateKey.private_bytes(

--- a/axiom/plugins/mantissacmd.py
+++ b/axiom/plugins/mantissacmd.py
@@ -156,10 +156,12 @@ class Mantissa(axiomatic.AxiomaticCommand):
                     key_cert_sign=False,
                     crl_sign=False,
                     encipher_only=False,
-                    decipher_only=False))
+                    decipher_only=False),
+                critical=False)
             .add_extension(
                 x509.ExtendedKeyUsage([
-                    ExtendedKeyUsageOID.SERVER_AUTH]))
+                    ExtendedKeyUsageOID.SERVER_AUTH]),
+                critical=False)
             .sign(
                 private_key=privateKey,
                 algorithm=hashes.SHA256(),

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "cssutils>=0.9.5",
         "Nevow>=0.9.5",
         "PyCrypto",
+        "cryptography>=1.0",
         ],
     packages=find_packages() + ['axiom.plugins', 'nevow.plugins'],
     include_package_data=True,

--- a/xmantissa/test/test_mantissacmd.py
+++ b/xmantissa/test/test_mantissacmd.py
@@ -42,7 +42,7 @@ class CertificateTestCase(CommandStubMixin, TestCase):
         Get the SSL certificate from an Axiom store directory.
         """
         certFile = FilePath(self.dbdir).child('files').child('server.pem')
-        return Certificate.loadPEM(certFile.open('rb').read())
+        return Certificate.loadPEM(certFile.getContent())
 
 
     def test_uniqueSerial(self):

--- a/xmantissa/test/test_mantissacmd.py
+++ b/xmantissa/test/test_mantissacmd.py
@@ -4,8 +4,6 @@
 Tests for I{axiomatic mantissa} and other functionality provided by
 L{axiom.plugins.mantissacmd}.
 """
-import gc
-
 from twisted.trial.unittest import TestCase
 from twisted.python.filepath import FilePath
 from twisted.internet.ssl import Certificate
@@ -57,13 +55,11 @@ class CertificateTestCase(CommandStubMixin, TestCase):
         self.dbdir = self.mktemp()
         self.store = Store(self.dbdir)
         m.parseOptions(['--admin-password', 'foo'])
-        gc.collect()
         cert1 = self._getCert()
 
         self.dbdir = self.mktemp()
         self.store = Store(self.dbdir)
         m.parseOptions(['--admin-password', 'foo'])
-        gc.collect()
         cert2 = self._getCert()
 
         self.assertNotEqual(cert1.serialNumber(), cert2.serialNumber())
@@ -79,7 +75,6 @@ class CertificateTestCase(CommandStubMixin, TestCase):
         self.dbdir = self.mktemp()
         self.store = Store(filesdir=FilePath(self.dbdir).child("files").path)
         m.parseOptions(['--admin-user', 'admin@example.com', '--admin-password', 'foo'])
-        gc.collect()
         cert = self._getCert()
         self.assertEqual(cert.getSubject().commonName, "example.com")
 


### PR DESCRIPTION
Fixes #43.
#45 introduced a workaround into the tests that this branch needs to remove, don't land until #45 has landed and I've updated this branch.
