### PR TITLE
Remove unused nevow.livepage support code.

### DIFF
--- a/doc/listings/interstore/cal.py
+++ b/doc/listings/interstore/cal.py
@@ -32,7 +32,7 @@ class Busy(Exception):
 class MakeAppointment(Command):
     arguments = [("whom", SenderArgument()), ("when", String())]
     response = [("appointmentID", Unicode())]
-    errors = {"busy": Busy}
+    errors = {Busy: "busy"}
 
 
 class Appointment(Item, AMPReceiver):

--- a/xmantissa/test/test_theme.py
+++ b/xmantissa/test/test_theme.py
@@ -241,7 +241,7 @@ class AthenaUnsupported(TestCase):
 
     def test_navPage(self):
         """
-        Test that L{webapp.GenericNavigationLivePage} supports theming of
+        Test that L{webapp.GenericNavigationAthenaPage} supports theming of
         Athena's unsupported-browser page based on an L{ITemplateNameResolver}
         installed on the viewing user's store.
         """

--- a/xmantissa/webapp.py
+++ b/xmantissa/webapp.py
@@ -21,7 +21,7 @@ from axiom.dependency import dependsOn
 from axiom.userbase import getAccountNames
 
 from nevow.rend import Page
-from nevow import livepage, athena
+from nevow import athena
 from nevow.inevow import IRequest
 from nevow import tags as t
 from nevow import url
@@ -329,29 +329,6 @@ class GenericNavigationPage(_FragmentWrapperMixin, Page, _ShellRenderingMixin):
         Page.__init__(self, docFactory=webapp.getDocFactory('shell'))
         _ShellRenderingMixin.__init__(self, webapp, pageComponents, username)
         _FragmentWrapperMixin.__init__(self, fragment, pageComponents)
-
-
-class GenericNavigationLivePage(_FragmentWrapperMixin, livepage.LivePage, _ShellRenderingMixin):
-    def __init__(self, webapp, fragment, pageComponents, username):
-        livepage.LivePage.__init__(self, docFactory=webapp.getDocFactory('shell'))
-        _ShellRenderingMixin.__init__(self, webapp, pageComponents, username)
-        _FragmentWrapperMixin.__init__(self, fragment, pageComponents)
-
-    # XXX TODO: support live nav, live fragments somehow
-    def render_head(self, ctx, data):
-        ctx.tag[t.invisible(render=t.directive("liveglue"))]
-        return _FragmentWrapperMixin.render_head(self, ctx, data)
-
-    def goingLive(self, ctx, client):
-        getattr(self.fragment, 'goingLive', lambda x, y: None)(ctx, client)
-
-    def locateHandler(self, ctx, path, name):
-        handler = getattr(self.fragment, 'locateHandler', None)
-
-        if handler is None:
-            return getattr(self.fragment, 'handle_' + name)
-        else:
-            return handler(ctx, path, name)
 
 
 


### PR DESCRIPTION
This isn't actually used anymore (as best I can tell), but importing it still breaks with Nevow 0.13.0 (not released yet).
