### PR TITLE
Pass --rcfile to coverage run.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,9 @@ deps=
     coverage
 commands=
     pip list
-    coverage run {envdir}/bin/trial \
-        --temp-directory={envdir}/_trial_temp {posargs:xmantissa}
+    coverage run --rcfile={toxinidir}/.coveragerc \
+        {envdir}/bin/trial \
+        --temp-directory={envdir}/_trial_temp \
+        {posargs:xmantissa}
     coverage report --rcfile={toxinidir}/.coveragerc
     coverage html --rcfile={toxinidir}/.coveragerc --directory {envdir}/_coverage


### PR DESCRIPTION
This was causing the `.coveragerc` settings not to actually take effect.
